### PR TITLE
Fix Index Notation Possible Error

### DIFF
--- a/slides/L02P01-vectorcalc.tex
+++ b/slides/L02P01-vectorcalc.tex
@@ -75,7 +75,7 @@ How to find $\pderiv[L]{\vtheta} = [\pderiv[L]{\theta_i}]_i$? \pause
 \vx\transpose\vy &= \sum_i x_i y_i \\ \Pause
 \vy = f(\vx) \vx &\implies y_i = f(\vx) x_i \\ \Pause
 \mat A \vx &=\, ? \\ \Pause
-{[\mat{A} \vx]_j} &= \sum_{j} A_{ij} x_j \\ \Pause
+{[\mat{A} \vx]_i} &= \sum_{j} A_{ij} x_j \\ \Pause
 \mat A\vx &= \left[\sum_j A_{ij} x_j\right]_i
 \end{align}
 \end{frame}


### PR DESCRIPTION
Hello,

Index Notation Slide on Lecture 2:

![image](https://user-images.githubusercontent.com/60236643/196004745-7d6e20ee-3a78-4af1-b95b-1c53f14e22a0.png)

I think the **j** subscript should be replaced by **i**, on the LHS of the equation.